### PR TITLE
Let non-preenrolled users sign in, log better errors

### DIFF
--- a/backend/src/db/course-repo.js
+++ b/backend/src/db/course-repo.js
@@ -34,6 +34,7 @@ export async function confirmPreenrollments (email, userId) {
       if (courseSnapshot && courseSnapshot.exists()) {
         return Object.keys(courseSnapshot.val())
       }
+      return []
     })
     .then(courseKeys => {
       let courseActions = []

--- a/backend/src/routes/auth-routes.js
+++ b/backend/src/routes/auth-routes.js
@@ -44,6 +44,7 @@ export const config = [
         const encodedJwt = encodeURIComponent(jwt)
         reply().redirect(`${env.config.serverBaseURL}/sign-in?token=${encodedJwt}`)
       } catch (error) {
+        console.error(`Unable to sign MSU user in with code ${request.query.code}. Reason:`, error)
         reply(boom.unauthorized(error.message))
       }
     }
@@ -73,6 +74,7 @@ export const config = [
 
         reply().redirect(`${env.config.serverBaseURL}/`)
       } catch (error) {
+        console.error(`Unable to connect GitHub account with state ${request.query.state}. Reason:`, error)
         reply(boom.unauthorized(error.message))
       }
     }


### PR DESCRIPTION
@chrisvfritz 

Stuart couldn't sign in because he wasn't pre-enrolled in a course. Turns out that `null.forEach(...)` doesn't fly in JavaScript. Who knew.