### PR TITLE
fix bug in course progress bar

### DIFF
--- a/frontend/src/pages/course.vue
+++ b/frontend/src/pages/course.vue
@@ -48,13 +48,14 @@
               class="meter-percent-to-max-grade"
             />
             <div
-              v-for="milestone in gradeMilestones"
+              v-for="(milestone, milestoneIndex) in gradeMilestones"
               :data-grade="milestone"
               :style="{ left: milestone / maxGrade * 100 + '%' }"
               :class="{
                 active: (
                   achievedGradePoints >= milestone &&
-                  achievedGradePoints < milestone + gradeMilestones[0]
+                  achievedGradePoints < maxGrade &&
+                  achievedGradePoints < gradeMilestones[milestoneIndex + 1]
                 )
               }"
               class="course-grade-milestone"


### PR DESCRIPTION
During QA, Katie found an issue in how the course progress bar was displaying (e.g. when a student at a 2.3, both 2.5 and 2.0 would be highlighted).