### PR TITLE
Remove external link icons from Code Review links per Katie's request

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -98,7 +98,7 @@ a
     &:hover
       color: inherit
       text-decoration: none
-  &:not(.button):not(.external-icon)[target=_blank]:not([href$=".jpg"]):not([href$=".jpeg"]):not([href$=".svg"]):not([href$=".png"]):not([href$=".gif"])
+  &:not(.button):not(.icon-link)[target=_blank]:not([href$=".jpg"]):not([href$=".jpeg"]):not([href$=".svg"]):not([href$=".png"]):not([href$=".gif"])
     &:after
       $external-link-symbol-size = .7em
       display: inline-block

--- a/frontend/src/components/code-reviews.vue
+++ b/frontend/src/components/code-reviews.vue
@@ -30,15 +30,15 @@
                 </router-link>
               </td>
               <td class="code-review-links">
-                <a :href="getFirstIssueUrl(codeReview)" target="_blank" class="external-icon" alt="Open the GitHub issue in a new tab" title="Open this issue on GitHub">
+                <a :href="getFirstIssueUrl(codeReview)" target="_blank" class="icon-link" alt="Open the GitHub issue in a new tab" title="Open this issue on GitHub">
                   <span class="fa fa-exclamation-circle" aria-hidden="true"></span>
                 </a>
                 &nbsp;
-                <a :href="getGitHubProjectUrl(codeReview)" target="_blank" class="external-icon" alt="Open the GitHub code in a new tab" title="View the code on GitHub">
+                <a :href="getGitHubProjectUrl(codeReview)" target="_blank" class="icon-link" alt="Open the GitHub code in a new tab" title="View the code on GitHub">
                   <span class="fa fa-code" aria-hidden="true"></span>
                 </a>
                 &nbsp;
-                <a :href="getProjectHostedUrl(codeReview)" target="_blank" class="external-icon" alt="Open the hosted site in a new tab" title="View the hosted site">
+                <a :href="getProjectHostedUrl(codeReview)" target="_blank" class="icon-link" alt="Open the hosted site in a new tab" title="View the hosted site">
                   <span class="fa fa-globe" aria-hidden="true"></span>
                 </a>
               </td>


### PR DESCRIPTION
@chrisvfritz 

Is the class name confusing? I was going for "this `a` is already an external link icon so the extra external link symbol isn't necessary" ... but in fewer words. 😆