### PR TITLE
Student dashboard twerks

### DIFF
--- a/frontend/src/components/course-progress.vue
+++ b/frontend/src/components/course-progress.vue
@@ -117,12 +117,12 @@ export default {
     getCurrentGradeStyle (student) {
       const currentGrade = courseUserGradeCurrentRounded(this.course, student)
       const deltaGrade = currentGrade - this.expectedGrade
-      // Threshold is the expected grade after two weeks of lesson work
-      const warningThreshold = -2 * gradeMax / normalizedSemesterWeeks
+      // Threshold is the expected grade after one week of lesson work
+      const gradeThreshold = gradeMax / normalizedSemesterWeeks
 
-      if (deltaGrade >= 0) {
+      if (deltaGrade >= gradeThreshold) {
         return 'allstar-grade'
-      } else if (deltaGrade <= warningThreshold) {
+      } else if (deltaGrade <= -gradeThreshold) {
         return 'warning-grade'
       } else {
         return ''


### PR DESCRIPTION
@KatieMFritz 

1. Remove Proj. Active column from Student Progress dashboard
2. Remove Proj. Delta column from Student Progress dashboard
3. Introduce grade point delta column to show how far ahead/behind each student is
4. Students behind by one week's grade (-0.29) or more will show grade in a red color
5. Students ahead by one week's grade (0.29) or more will show grade in a green color