### PR TITLE
Added tooltips for -- values in student progress dashboard

### DIFF
--- a/frontend/src/components/course-progress.vue
+++ b/frontend/src/components/course-progress.vue
@@ -46,10 +46,10 @@
           >
             ({{ getCurrentGradeDelta(student) }})
           </td>
-          <td class="numeric-cell">
+          <td class="numeric-cell" :title="isNaN(maxDaysProjectStaleFor(student)) ? 'This student has no submitted, unapproved projects where the instructor was last to comment' : ''">
             {{ maxDaysProjectStaleFor(student) }}
           </td>
-          <td class="numeric-cell">
+          <td class="numeric-cell" :title="isNaN(maxDaysProjectOngoingFor(student)) ? 'This student has no submitted, unapproved projects' : ''">
             {{ maxDaysProjectOngoingFor(student) }}
           </td>
           <td class="numeric-cell">


### PR DESCRIPTION
@KatieMFritz 

1. When the Days Stale column shows "--", a tooltip explains "This student has no submitted, unapproved projects where the instructor was last to comment"
2. When the Days Open column shows "--", a tooltip explains "This student has no submitted, unapproved projects"