### PR TITLE
New naming convention for project subdomains

### DIFF
--- a/frontend/src/helpers/computed/course-project-completion-hosted-subdomain.js
+++ b/frontend/src/helpers/computed/course-project-completion-hosted-subdomain.js
@@ -6,14 +6,12 @@ const maxChars = 30
 
 export default (course, projectCompletion) => {
   const user = userByKey(projectCompletion.students[0]['.key'])
-  const username = user.email
-    .replace(/@.+/, '')
+  const username = user.github.login
     .replace(/[^a-z0-9]+/gi, '')
     .slice(0, 15)
   const domainSuffix = projectCompletion.lessonKey
     .replace(/[^a-z0-9-]+/gi, '')
     .replace(/^-+/g, '')
     .replace(/-+$/g, '')
-    .slice(0, maxChars - username.length - 1)
-  return [username, domainSuffix].join('-').toLowerCase()
+  return [username, domainSuffix].join('-').toLowerCase().slice(0, maxChars)
 }

--- a/frontend/test/unit/specs/helpers/computed/course-project-completion-hosted-subdomain.spec.js
+++ b/frontend/test/unit/specs/helpers/computed/course-project-completion-hosted-subdomain.spec.js
@@ -18,7 +18,9 @@ describe('@helpers/computed/course-project-completion-hosted-subdomain.js', () =
         lessonKey: 'project-key'
       },
       user: {
-        email: 'homer.j.simpson@nucular-plant.com'
+        github: {
+          login: 'homer.j.simpson'
+        }
       }
     }, 'homerjsimpson-project-key')
   })
@@ -29,7 +31,9 @@ describe('@helpers/computed/course-project-completion-hosted-subdomain.js', () =
         lessonKey: 'project-key-project-key-project-key-project-key'
       },
       user: {
-        email: 'abcdefghijklmnopqrstuvwxyz0123456789@nucular-plant.com'
+        github: {
+          login: 'abcdefghijklmnopqrstuvwxyz0123456789'
+        }
       }
     }, 'abcdefghijklmno-project-key-pr')
   })
@@ -40,7 +44,9 @@ describe('@helpers/computed/course-project-completion-hosted-subdomain.js', () =
         lessonKey: '-_/\\ABCabc123-_/\\'
       },
       user: {
-        email: 'homer_simpson.1-1@nucular-plant.com'
+        github: {
+          login: 'homer_simpson.1-1'
+        }
       }
     }, 'homersimpson11-abcabc123')
   })
@@ -52,9 +58,25 @@ describe('@helpers/computed/course-project-completion-hosted-subdomain.js', () =
         lessonKey: '-_/\\ABCabc123-_/\\'
       },
       user: {
-        email: 'homer_simpson.1-1@nucular-plant.com'
+        github: {
+          login: 'homer_simpson.1-1'
+        }
       }
     }, 'homersimpson11-abcabc123')
+  })
+
+  it('uses GitHub login instead of email', () => {
+    assertSubdomainWith({
+      projectCompletion: {
+        lessonKey: 'js-intro'
+      },
+      user: {
+        email: 'homer_simpson.1-1@nucular-plant.com',
+        github: {
+          login: 'Hsimpson'
+        }
+      }
+    }, 'hsimpson-js-intro')
   })
 
   it('produces non-cryptic subdomains for real users and projects', () => {
@@ -63,7 +85,9 @@ describe('@helpers/computed/course-project-completion-hosted-subdomain.js', () =
         lessonKey: 'html-terminal-and-git'
       },
       user: {
-        email: 'erik.gillespie@gmail.com'
+        github: {
+          login: 'erik.gillespie'
+        }
       }
     }, 'erikgillespie-html-terminal-an')
 
@@ -72,7 +96,9 @@ describe('@helpers/computed/course-project-completion-hosted-subdomain.js', () =
         lessonKey: 'css-frameworks'
       },
       user: {
-        email: 'katie@katiemfritz.com'
+        github: {
+          login: 'katie'
+        }
       }
     }, 'katie-css-frameworks')
   })


### PR DESCRIPTION
@KatieMFritz 

Instead of using email address handle and the cryptic project key for subdomains, the app now uses GitHub login and the lesson key, both of which should be easily recognizable.

Before: `https://levins23-khxn-8th0o_1eurjy-_.herokuapp.com/`
After: `https://levinsonmm-js-create-an-api-wi.herokuapp.com/`