### PR TITLE
Only show an instructor's own courses on the student progress dashboard

### DIFF
--- a/frontend/src/pages/student-progress.vue
+++ b/frontend/src/pages/student-progress.vue
@@ -19,16 +19,27 @@ export default {
   computed: {
     ...courseGetters,
     coursesSortedByKey () {
-      return sortBy(this.courses, [course => course['.key']])
+      return sortBy(this.availableCourses, [course => course['.key']])
+    }
+  },
+  data () {
+    return {
+      availableCourses: []
     }
   },
   created () {
-    // Retrieve the large fields so projectCompletions are available
+    const currentUserKey = store.state.users.currentUser.uid
+
+    // Retrieve the large fields of the instructor's courses
+    // so project completions are available
     this.courses.forEach(course => {
-      store.dispatch('syncLargeFieldsOfResource', {
-        resourceName: 'courses',
-        resourceKey: course['.key']
-      })
+      if (course.instructorKeys.indexOf(currentUserKey) !== -1) {
+        store.dispatch('syncLargeFieldsOfResource', {
+          resourceName: 'courses',
+          resourceKey: course['.key']
+        })
+        this.availableCourses.push(course)
+      }
     })
   }
 }


### PR DESCRIPTION
@KatieMFritz 

1. Only show an instructor's own courses on student progress page
2. This should have a performance benefit since I only pull down large fields after identifying which courses to show.