### PR TITLE
Check for valid courses before fetching data on code review page

### DIFF
--- a/frontend/src/components/code-reviews.vue
+++ b/frontend/src/components/code-reviews.vue
@@ -73,7 +73,6 @@
 import {
   coursePermissionMethods, userGetters, lessonGetters
 } from '@state/helpers'
-import courseLessons from '@helpers/finders/course-lessons'
 import courseUserGradeCurrentRounded from '@helpers/computed/course-user-grade-current-rounded'
 import courseProjectCompletionRepoName from '@helpers/computed/course-project-completion-repo-name'
 import courseProjectCompletionHostedUrl from '@helpers/computed/course-project-completion-hosted-url'
@@ -138,16 +137,18 @@ export default {
   created () {
     // Retrieve the large fields so projectCompletions are available
     this.courses.forEach(course => {
+      if (!course) return
+
       store.dispatch('syncLargeFieldsOfResource', {
         resourceName: 'courses',
         resourceKey: course['.key']
       })
 
       // Retrieve the large fields so projects are available
-      courseLessons(course).forEach(lesson => {
+      course.lessonKeys.forEach(lessonKey => {
         store.dispatch('syncLargeFieldsOfResource', {
           resourceName: 'lessons',
-          resourceKey: lesson['.key']
+          resourceKey: lessonKey
         })
       })
     })


### PR DESCRIPTION
@KatieMFritz 

The bug in code reviews appears to have been missing data — my guess is a course, lesson, or link between a course and lesson was removed for one of your code reviews.

1. Make sure the course "exists"
2. Avoid looking over all lessons to find a course-lesson link before pulling down large fields and just use the lesson key from the course.