### PR TITLE
Migrate msu.lansing.codes to codelab.cas.msu.edu

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The development environment can be launched for either the frontend or the backe
 When builds pass on CircleCI, GitHub's:
 
 - `master` branch deploys to the [staging server](https://msu-codes-staging.herokuapp.com)
-- `production` branch deploys to the [production server](https://msu.lansing.codes/)
+- `production` branch deploys to the [production server](https://codelab.cas.msu.edu/)
 
 There are also several commands you can use:
 

--- a/backend/env/dev/config.js
+++ b/backend/env/dev/config.js
@@ -10,6 +10,6 @@ module.exports = {
   githubAuthClientID: '740ecf728a1bf799961b',
   githubAuthClientSecret: '85174d69151083ce58a0c0775324e5f087f1a665',
 
-  githubEventsBaseURL: 'https://msu.lansing.codes/api',
+  githubEventsBaseURL: 'https://codelab.cas.msu.edu/api',
   githubEventsPath: '/github-events/871255a9-83c9-496b-90b8-24440f16dc77'
 }

--- a/backend/env/production/config.js
+++ b/backend/env/production/config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  serverBaseURL: 'https://msu.lansing.codes',
+  serverBaseURL: 'https://codelab.cas.msu.edu',
 
   msuAuthBaseURL: 'https://oauth.itservices.msu.edu',
   msuAuthClientID: 'OAuth-MI-MSU-Lansing-Codes',
@@ -9,6 +9,6 @@ module.exports = {
   githubAuthClientID: '0a6d06c7ff456bd2175b',
   githubAuthClientSecret: 'f1be467bfbde6b2587e8377af80d1b4c465a3ae4',
 
-  githubEventsBaseURL: 'https://msu.lansing.codes/api',
+  githubEventsBaseURL: 'https://codelab.cas.msu.edu/api',
   githubEventsPath: '/github-events/2ce78554-4c4b-46fb-90ef-a409056f27b0'
 }

--- a/backend/env/testing/config.js
+++ b/backend/env/testing/config.js
@@ -9,6 +9,6 @@ module.exports = {
   githubAuthClientID: '740ecf728a1bf799961b',
   githubAuthClientSecret: '85174d69151083ce58a0c0775324e5f087f1a665',
 
-  githubEventsBaseURL: 'https://msu.lansing.codes/api',
+  githubEventsBaseURL: 'https://codelab.cas.msu.edu/api',
   githubEventsPath: '/github-events/eb564a2f-fca6-41fa-8e6d-11009a330e0b'
 }

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -97,8 +97,8 @@ The production database (`MsuLansingCodes`) is configured to take daily backups.
    4. Paste the rules from your clipboard into the edit box.
    5. Click "Publish" at the top of the edit box.
 6. Disable "Maintenance Mode" for `msu-lansing-codes` in Heroku if it was enabled.
-7. Verify that you are able to sign into [msu.lansing.codes][3] and access the restored data in the website.
+7. Verify that you are able to sign into [codelab.cas.msu.edu][3] and can access the restored data in the website.
 
 [1]: https://firebase.google.com/docs/cli/ "Firebase CLI Reference"
 [2]: https://console.firebase.google.com/ "Firebase Console"
-[3]: https://msu.lansing.codes/ "MSU Codes Homepage"
+[3]: https://codelab.cas.msu.edu/ "MSU Codes Homepage"

--- a/frontend/src/env/prod.js
+++ b/frontend/src/env/prod.js
@@ -1,7 +1,7 @@
 export default {
   msuAuthClientId: 'OAuth-MI-MSU-Lansing-Codes',
   githubAuthClientId: '0a6d06c7ff456bd2175b',
-  githubAuthRedirectURL: 'https://msu.lansing.codes/auth/github/callback',
+  githubAuthRedirectURL: 'https://codelab.cas.msu.edu/auth/github/callback',
 
   firebaseConfig: {
     apiKey: 'AIzaSyCkUJWAFZaKbnywIxJhOxnyshaDrX5j_dA',

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "deploy:staging-to-production": "git fetch origin && git push --force origin origin/master:production",
     "deploy-force:local-to-staging": "git push --force ssh://git@heroku.com/msu-codes-staging.git `git rev-parse --abbrev-ref HEAD`:master",
     "deploy-force:local-to-production": "git push --force ssh://git@heroku.com/msu-lansing-codes.git `git rev-parse --abbrev-ref HEAD`:master",
-    "ssl:renew": "sudo certbot certonly --manual -d msu.lansing.codes && sudo heroku certs:update /etc/letsencrypt/live/msu.lansing.codes/fullchain.pem /etc/letsencrypt/live/msu.lansing.codes/privkey.pem --confirm msu-lansing-codes"
+    "ssl:renew": "sudo certbot certonly --manual -d codelab.cas.msu.edu && sudo heroku certs:update /etc/letsencrypt/live/msu.lansing.codes/fullchain.pem /etc/letsencrypt/live/msu.lansing.codes/privkey.pem --confirm msu-lansing-codes"
   },
   "dependencies": {
     "npm-run-all": "^3.1.0"


### PR DESCRIPTION
@KatieMFritz 

Here are the configuration changes we need in place before we can migrate the domain.

During the production deployment, the following applications will also need to be updated:

1. Heroku - Add new domain to [settings](https://dashboard.heroku.com/apps/msu-lansing-codes/settings). (Sam has already done this)
2. GitHub OAuth - Replace [callback URL](https://github.com/settings/applications/410461) with new domain.
3. MSU OAuth - Ask [IT Services]() to update callback URL for Client ID `OAuth-MI-MSU-Lansing-Codes`.
4. Firebase - Add new domain to [list of authorized domains](https://console.firebase.google.com/u/0/project/msulansingcodes/authentication/providers).
5. Namecheap - [Add redirect](https://ap.www.namecheap.com/domains/domaincontrolpanel/lansing.codes) from old domain to new. (Will need Chris to give me 2FA token or turn it off first)