### PR TITLE
Add link to MSU Teams

### DIFF
--- a/frontend/src/components/main-nav.vue
+++ b/frontend/src/components/main-nav.vue
@@ -18,9 +18,12 @@
         </router-link>
       </li>
       <li>
-        <router-link to="/community">
+        <a 
+          href="https://teams.microsoft.com/l/team/19%3aa868fa825a3445e7b7ed9b84e4e54483%40thread.skype/conversations?groupId=6128d6e2-b65b-4241-b297-40b0455aa007&tenantId=22177130-642f-41d9-9211-74237ad5687d"
+          target="_blank"
+          title="Open MSU Teams">
           Community
-        </router-link>
+        </a>
       </li>
     </ul>
     <ul class="main-nav-group-right">


### PR DESCRIPTION
Adds a "Community" link to the left-side navigation that opens MSU Teams in a new tab or window.

Hard-coded because I don't think `router-link` accepts absolute URLs to external sites?