### PR TITLE
Remove hashtag from front of links with names

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -90,7 +90,6 @@ a
     color: $design.branding.primary.dark
     position: relative
     &:hover:before
-      content: '#'
       position: absolute
       left: -0.8em
   &.container-link


### PR DESCRIPTION
@KatieMFritz I removed that weird # from the front of links that have a name attribute.