### PR TITLE
Change contrast for low grades

### DIFF
--- a/frontend/src/components/course-progress.vue
+++ b/frontend/src/components/course-progress.vue
@@ -213,7 +213,7 @@ export default {
 @import '../meta'
 
 .warning-grade
-  color: $design.branding.danger.light
+  color: $design.branding.danger.dark
 .allstar-grade
   color: $design.branding.success.light
 .grade-delta


### PR DESCRIPTION
The only place I'm getting contrast errors is for warning grades on the darker table background. Suggested fix: use `$design.branding.danger.dark` instead of `$design.branding.danger.light`. It's a little dark, but at least it meets accessibility requirements.