### PR TITLE
Remove explicit overflow-y on rendered content

### DIFF
--- a/frontend/src/components/rendered-content.vue
+++ b/frontend/src/components/rendered-content.vue
@@ -222,7 +222,6 @@ export default {
   padding: $design.layout.gutterWidth
   background-color: $design.branding.default.light
   border-radius: $design.control.border.radius
-  overflow-y: auto
   img
     display: block
     margin: 0 auto


### PR DESCRIPTION
@KatieMFritz Remove explicit `overflow-y` on rendered content to prevent scrollbar flicker on Chrome.

Addresses the flickering scrollbar when zoomed at 90% in Chrome on the page `/courses/MI-449-SS18-740/lessons/css-sass-intro/1`.