### PR TITLE
Fetch large course fields on student progress when needed instead of …

### DIFF
--- a/frontend/src/components/course-progress.vue
+++ b/frontend/src/components/course-progress.vue
@@ -62,6 +62,7 @@
 </template>
 
 <script>
+import store from '@state/store'
 import differenceInDays from 'date-fns/difference_in_days'
 import { userGetters } from '@state/helpers'
 import courseUserGradeCurrentRounded from '@helpers/computed/course-user-grade-current-rounded'
@@ -76,6 +77,12 @@ export default {
       type: Object,
       required: true
     }
+  },
+  created () {
+    store.dispatch('syncLargeFieldsOfResource', {
+      resourceName: 'courses',
+      resourceKey: this.course['.key']
+    })
   },
   computed: {
     ...userGetters,

--- a/frontend/src/pages/student-progress.vue
+++ b/frontend/src/pages/student-progress.vue
@@ -18,29 +18,15 @@ export default {
   },
   computed: {
     ...courseGetters,
+    availableCourses () {
+      const currentUserKey = store.state.users.currentUser.uid
+      return this.courses.filter(
+        course => course.instructorKeys.indexOf(currentUserKey) !== -1
+      )
+    },
     coursesSortedByKey () {
       return sortBy(this.availableCourses, [course => course['.key']])
     }
-  },
-  data () {
-    return {
-      availableCourses: []
-    }
-  },
-  created () {
-    const currentUserKey = store.state.users.currentUser.uid
-
-    // Retrieve the large fields of the instructor's courses
-    // so project completions are available
-    this.courses.forEach(course => {
-      if (course.instructorKeys.indexOf(currentUserKey) !== -1) {
-        store.dispatch('syncLargeFieldsOfResource', {
-          resourceName: 'courses',
-          resourceKey: course['.key']
-        })
-        this.availableCourses.push(course)
-      }
-    })
   }
 }
 </script>


### PR DESCRIPTION
@KatieMFritz 

Fetches large course fields on student progress when needed instead of attempting to pre-fetch all the required data before the page component is created. The Student Progress page can be refreshed and will load the data correctly and now each component is more correctly responsible for loading its own data.