### PR TITLE
Add Projected Grade column for student progress dashboard

### DIFF
--- a/frontend/src/components/course-progress.vue
+++ b/frontend/src/components/course-progress.vue
@@ -26,7 +26,7 @@
       <tbody>
         <tr v-for="student in studentsInCourse">
           
-          // Name and Github link
+          <!-- Name and Github link -->
           <td>
             <a
               v-if="student.github"
@@ -40,7 +40,7 @@
             </span>
           </td>
           
-          // Current grade
+          <!-- Current grade -->
           <td
             class="numeric-cell"
             :class="getCurrentGradeStyle(student)"
@@ -54,22 +54,22 @@
             ({{ getCurrentGradeDelta(student) }})
           </td>
           
-          // Projected Grade
+          <!-- Projected Grade -->
           <td class="numeric-cell">
             ({{ getProjectedGrade(student) }})
           </td>
           
-          // Days Open
+          <!-- Days Open -->
           <td class="numeric-cell" :title="isNaN(maxDaysProjectOngoingFor(student)) ? 'This student has no submitted, unapproved projects' : ''">
             {{ maxDaysProjectOngoingFor(student) }}
           </td>
           
-          // Days Stale
+          <!-- Days Stale -->
           <td class="numeric-cell" :title="isNaN(maxDaysProjectStaleFor(student)) ? 'This student has no submitted, unapproved projects where the instructor was last to comment' : ''">
             {{ maxDaysProjectStaleFor(student) }}
           </td>
           
-          // Days Inactive
+          <!-- Days Inactive -->
           <td class="numeric-cell">
             {{ daysSinceLastProjectActivity(student) }}
           </td>


### PR DESCRIPTION
@egillespie I would really like to see what grade a student is heading towards to help me with my weekly check-ins. I want to see the real grade, not the rounded grade, so I know if they're closer to a higher or lower grade.

I tried to do everything right in this file, but please check my work! I also broke up the `tbody` section a bit because it's getting hard to parse with all the columns, but feel free to make me change it back if it breaks our style guide. My local install of this isn't set up properly, so I haven't tested it. 😬 