### PR TITLE
Make "changes requested" pill red

### DIFF
--- a/frontend/src/components/lessons-map.vue
+++ b/frontend/src/components/lessons-map.vue
@@ -520,7 +520,7 @@ $lesson-card-approved-bg = lighten($design.branding.muted.light.success, 50%)
     &:hover
       border: 1px solid $design.control.border.color
   &.changes-requested
-    background-color: $design.branding.muted.light.yellow
+    background-color: $design.branding.muted.light.red
     bottom: -5px
   &.awaiting-feedback
     bottom: -5px


### PR DESCRIPTION
changes background for 'changes requested' pill to red to try to catch students' attention more. I haven't been able to test it completely in context, but the color itself looks okay, and it's not a contrast error.

My hypothesis (from observing students) is that students aren't noticing from the wording or subtle color changes that a project is ready for them to revisit, and that if it's red, they're more likely to notice. 
