### PR TITLE
Lazy load pending students, delete course/lesson relationships sequentially

### DIFF
--- a/backend/src/db/course/delete.js
+++ b/backend/src/db/course/delete.js
@@ -1,27 +1,24 @@
 export default async (courseRecord, options) => {
   // Delete foreign keys first
-  const removeRelationships = []
-  if (courseRecord.instructors) {
-    removeRelationships.push(
-      courseRecord.removeInstructors(courseRecord.instructors)
-    )
-  }
-  if (courseRecord.students) {
-    removeRelationships.push(
-      courseRecord.removeStudents(courseRecord.students)
-    )
-  }
-  if (courseRecord.lessons) {
-    removeRelationships.push(
-      courseRecord.removeLessons(courseRecord.lessons)
-    )
-  }
-  if (courseRecord.pendingStudents) {
-    removeRelationships.push(
-      courseRecord.removePendingStudents(courseRecord.pendingStudents)
-    )
+  const instructors = await courseRecord.getInstructors(options)
+  if (instructors.length) {
+    await courseRecord.removeInstructors(instructors, options)
   }
 
-  return Promise.all(removeRelationships)
-    .then(() => courseRecord.destroy(options))
+  const students = await courseRecord.getStudents(options)
+  if (students.length) {
+    await courseRecord.removeStudents(students, options)
+  }
+
+  const lessons = await courseRecord.getLessons(options)
+  if (lessons.length) {
+    await courseRecord.removeLessons(lessons, options)
+  }
+
+  const pendingStudents = await courseRecord.getPendingStudents(options)
+  if (pendingStudents.length) {
+    await courseRecord.removePendingStudents(pendingStudents, options)
+  }
+
+  await courseRecord.destroy(options)
 }

--- a/backend/src/db/course/index.js
+++ b/backend/src/db/course/index.js
@@ -96,13 +96,8 @@ Lesson.belongsToMany(Course, {
 // course_student_pending relationship
 Course.hasMany(CourseStudentPending, {
   as: 'pendingStudents',
-  foreignKey: 'course_id',
-  sourceKey: 'course_id'
-})
-
-CourseStudentPending.belongsTo(Course, {
-  as: 'course',
-  foreignKey: 'course_id'
+  foreignKey: 'courseId',
+  sourceKey: 'courseId'
 })
 
 export default Course

--- a/backend/src/db/course/student-pending/read-for-course-id.js
+++ b/backend/src/db/course/student-pending/read-for-course-id.js
@@ -1,8 +1,0 @@
-import CourseStudentPending from './index'
-
-export default (courseId, options) => CourseStudentPending.findAll({
-  ...options,
-  where: {
-    courseId
-  }
-})

--- a/backend/src/db/lesson/delete.js
+++ b/backend/src/db/lesson/delete.js
@@ -3,26 +3,31 @@ import LessonProjectCriterion from './project-criterion'
 
 export default async (lessonRecord, options) => {
   // Delete foreign keys first
-  const removeRelationships = [
-    LessonLearningObjective.destroy({
-      ...options,
-      where: {
-        lessonId: lessonRecord.lessonId
-      }
-    }),
-    LessonProjectCriterion.destroy({
-      ...options,
-      where: {
-        lessonId: lessonRecord.lessonId
-      }
-    })
-  ]
+  await LessonLearningObjective.destroy({
+    ...options,
+    where: {
+      lessonId: lessonRecord.lessonId
+    }
+  })
+
+  await LessonProjectCriterion.destroy({
+    ...options,
+    where: {
+      lessonId: lessonRecord.lessonId
+    }
+  })
 
   const prerequisiteLessons = await lessonRecord.getPrerequisiteLessons(options)
-  removeRelationships.push(
-    lessonRecord.removePrerequisiteLessons(prerequisiteLessons, options)
-  )
+  if (prerequisiteLessons.length) {
+    await lessonRecord.removePrerequisiteLessons(
+      prerequisiteLessons, options
+    )
+  }
 
-  return Promise.all(removeRelationships)
-    .then(() => lessonRecord.destroy(options))
+  const courses = await lessonRecord.getCourses(options)
+  if (courses.length) {
+    await lessonRecord.removeCourses(courses, options)
+  }
+
+  await lessonRecord.destroy(options)
 }

--- a/backend/src/routes/api/courses/_helpers/sync-pending-students.js
+++ b/backend/src/routes/api/courses/_helpers/sync-pending-students.js
@@ -1,12 +1,9 @@
-import readCourseStudentPendingRecordsForCourseId from 'db/course/student-pending/read-for-course-id'
 import createPendingStudentRecord from 'db/course/student-pending/create'
 import deletePendingStudentRecord from 'db/course/student-pending/delete'
 
 export default async ({ courseRecord, updatedCourse, transaction }) => {
   const pendingStudentRecords =
-    await readCourseStudentPendingRecordsForCourseId(
-      courseRecord.courseId, { transaction }
-    )
+    await courseRecord.getPendingStudents({ transaction })
 
   // Create pending students that don't already have a relationship
   const toCreate = updatedCourse.pendingStudentEmails.filter(

--- a/backend/src/translators/course/from-record.js
+++ b/backend/src/translators/course/from-record.js
@@ -1,5 +1,4 @@
 import dateToTimestamp from '../_helpers/date-to-timestamp'
-import readCourseStudentPendingRecordsForCourseId from 'db/course/student-pending/read-for-course-id'
 
 export default async ({ authUser, courseRecord, transaction }) => {
   // Whitelist of fields that are available to clients
@@ -43,18 +42,9 @@ export default async ({ authUser, courseRecord, transaction }) => {
   course.lessonIds = lessons.map(lessonRecord => lessonRecord.lessonId)
 
   // Translate pending students (emails only)
-  // Lazy-loading this relationship uses a bogus query:
-  // ``` sql
-  //   SELECT "course_id" AS "courseId", "email", "version", "course_id"
-  //   FROM "course_student_pending" AS "courseStudentPending"
-  //   WHERE "courseStudentPending"."course_id" = NULL;
-  // ```
-  // So use an explicit query using the courseId to avoid the outer joins
-  // that come with eager loading.
-  const pendingStudents = await readCourseStudentPendingRecordsForCourseId(
-    courseRecord.courseId,
-    { attributes: ['email'], transaction }
-  )
+  const pendingStudents = await courseRecord.getPendingStudents({
+    attributes: ['email'], transaction
+  })
   course.pendingStudentEmails = pendingStudents.map(
     courseStudentPendingRecord => courseStudentPendingRecord.email
   )


### PR DESCRIPTION
@KatieMFritz 

1. I figured out how to correctly lazy load `hasMany` relationships in Sequelize with the last PR so I doubled back and removed the pending students workaround I had put in place.
2. I think using `Promise.all` to delete all of a course or lesson's foreign key data was locking the table and preventing tests from cleaning up properly. I fixed this by deleting foreign key data sequentially.