### PR TITLE
Migrate to humanitycodes/codelab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/msu.lansing.codes
+    working_directory: ~/codelab
     parallelism: 1
     shell: /bin/bash --login
     # CircleCI 2.0 does not support environment variables that refer to each other
@@ -18,8 +18,8 @@ jobs:
     steps:
     # Setup PATH (can't do in environment section because PATH refers to itself)
     - run:
-        working_directory: ~/msu.lansing.codes
-        command: echo -e "export PATH=${PATH}:~/msu.lansing.codes/.yarn/bin:~/msu.lansing.codes/node_modules/.bin" >> $BASH_ENV
+        working_directory: ~/codelab
+        command: echo -e "export PATH=${PATH}:~/codelab/.yarn/bin:~/codelab/node_modules/.bin" >> $BASH_ENV
     # The following `checkout` command checks out your code to your working directory
     - checkout
     # Restore dependency caches
@@ -119,7 +119,7 @@ jobs:
     - store_test_results:
         path: ./test/dist/e2e-reports
   deploy_msu_staging:
-    working_directory: ~/msu.lansing.codes
+    working_directory: ~/codelab
     docker:
     - image: docker:stable-git
     steps:
@@ -128,7 +128,7 @@ jobs:
         name: Deploy master branch to msu-codes-staging on Heroku
         command: .circleci/deploy-heroku.sh msu-codes-staging
   deploy_codelab517_staging:
-    working_directory: ~/msu.lansing.codes
+    working_directory: ~/codelab
     docker:
     - image: docker:stable-git
     steps:
@@ -137,7 +137,7 @@ jobs:
         name: Deploy master branch to codelab517-staging on Heroku
         command: .circleci/deploy-heroku.sh codelab517-staging
   deploy_msu_production:
-    working_directory: ~/msu.lansing.codes
+    working_directory: ~/codelab
     docker:
     - image: docker:stable-git
     steps:
@@ -146,7 +146,7 @@ jobs:
         name: Deploy production branch to msu-lansing-codes on Heroku
         command: .circleci/deploy-heroku.sh msu-lansing-codes
   deploy_codelab517_production:
-    working_directory: ~/msu.lansing.codes
+    working_directory: ~/codelab
     docker:
     - image: docker:stable-git
     steps:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# MSU Codes
+# Code Lab
 
 ## Organization
 
 The codebase is split into several parts:
 
-* `.circleci` - Continuous integration configuration via [CircleCI](https://circleci.com/gh/chrisvfritz/msu.lansing.codes)
+* `.circleci` - Continuous integration configuration via [CircleCI](https://circleci.com/gh/humanitycodes/codelab)
 * `.vscode` - VS Code is the editor of choice for this project and workspace configuration is provided in this directory
 * `backend` - Code for the server-side API, which also hosts the client code in non-dev environments
 * `database` - Anything related specifically to the Postgres database (docs, migration scripts, etc.)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "private": true,
   "author": "Humanity Codes, LLC",
-  "homepage": "https://github.com/chrisvfritz/msu.lansing.codes#readme",
+  "homepage": "https://github.com/humanitycodes/codelab#readme",
   "description": "Learning Management System for Coding Courses",
   "contributors": [
     "Chris Fritz",
@@ -13,10 +13,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chrisvfritz/msu.lansing.codes.git"
+    "url": "git+https://github.com/humanitycodes/codelab.git"
   },
   "bugs": {
-    "url": "https://github.com/chrisvfritz/msu.lansing.codes/issues"
+    "url": "https://github.com/humanitycodes/codelab/issues"
   },
   "scripts": {
     "install:backend": "cd backend && cross-env NODE_ENV=development yarn --pure-lockfile",


### PR DESCRIPTION
@KatieMFritz 

1. Renamed `lansingcodelab` organization to `humanitycodes`
2. Upgraded `humanitycodes` to team org (for free, yay!)
3. Transferred `msu.lansing.codes` to `humanitycodes/codelab`
4. Updated references in code/docs/config

Two things you should do on your computer:

1. Change the origin of your local copy to `humanitycodes/codelab` or re-clone the project
2. Update your CircleCI bookmark to https://circleci.com/gh/humanitycodes/codelab