### PR TITLE
Sync deleted items a little better

### DIFF
--- a/frontend/src/state/modules/courses.js
+++ b/frontend/src/state/modules/courses.js
@@ -30,17 +30,25 @@ export default {
     syncCourse ({ dispatch }, courseId) {
       // Get a specific course from the API and merge it with the others
       return getCourse(courseId)
-        .then(course => dispatch('mergeCourses', [course]))
+        .then(course =>
+          dispatch('mergeCourses', [course])
+          .then(() => course)
+        )
         .catch(error => {
           if (error.response && error.response.status === 404) {
+            // Resolve null to indicate course was removed
             return dispatch('removeCourses', [courseId])
+              .then(() => null)
           }
           throw error
         })
     },
     syncAllCourses ({ commit }) {
       return getCourses()
-        .then(courses => commit('SET_ALL_COURSES', courses))
+        .then(courses => {
+          commit('SET_ALL_COURSES', courses)
+          return courses
+        })
         .catch(error => {
           commit('SET_ALL_COURSES', [])
           throw error

--- a/frontend/src/state/modules/lessons.js
+++ b/frontend/src/state/modules/lessons.js
@@ -30,10 +30,15 @@ export default {
     syncLesson ({ dispatch }, lessonId) {
       // Get a specific lesson from the API and merge it with the others
       return getLesson(lessonId)
-        .then(lesson => dispatch('mergeLessons', [lesson]))
+        .then(lesson =>
+          dispatch('mergeLessons', [lesson])
+          .then(() => lesson)
+        )
         .catch(error => {
           if (error.response && error.response.status === 404) {
+            // Resolve null to indicate lesson was removed
             return dispatch('removeLessons', [lessonId])
+              .then(() => null)
           }
           throw error
         })
@@ -41,7 +46,10 @@ export default {
     syncAllLessons ({ commit }) {
       // Get all available lessons from API and save them in the local state
       return getLessons()
-        .then(lessons => commit('SET_ALL_LESSONS', lessons))
+        .then(lessons => {
+          commit('SET_ALL_LESSONS', lessons)
+          return lessons
+        })
         .catch(error => {
           commit('SET_ALL_LESSONS', [])
           throw error

--- a/frontend/src/state/modules/project-completions.js
+++ b/frontend/src/state/modules/project-completions.js
@@ -29,10 +29,13 @@ export default {
       return getProjectCompletion(projectCompletionId)
         .then(projectCompletion =>
           dispatch('mergeProjectCompletions', [projectCompletion])
+          .then(() => projectCompletion)
         )
         .catch(error => {
           if (error.response && error.response.status === 404) {
+            // Resolve null to indicate project completion was removed
             return dispatch('removeProjectCompletions', [projectCompletionId])
+              .then(() => null)
           }
           throw error
         })
@@ -41,6 +44,7 @@ export default {
       return getProjectCompletions()
         .then(projectCompletions => {
           commit('SET_ALL_PROJECT_COMPLETIONS', projectCompletions)
+          return projectCompletions
         })
         .catch(error => {
           commit('SET_ALL_PROJECT_COMPLETIONS', [])

--- a/frontend/src/state/modules/resource-journal.js
+++ b/frontend/src/state/modules/resource-journal.js
@@ -1,4 +1,4 @@
-import { keys, get } from 'idb-keyval'
+import { keys, get, del } from 'idb-keyval'
 
 const syncActionName = {
   'course': 'syncCourse',
@@ -38,6 +38,10 @@ export default {
       const action = syncActionName[resourceType]
       if (!action) return
       return dispatch(action, resourceId)
+        .then(resource => {
+          // If the action resolved null, remove the resource from the journal
+          if (!resource) return del(resourceId)
+        })
     }
   },
   mutations: {

--- a/frontend/src/state/modules/users.js
+++ b/frontend/src/state/modules/users.js
@@ -108,7 +108,10 @@ export default {
     },
     syncAllUsers ({ commit }) {
       return getUsers()
-        .then(users => commit('SET_ALL_USERS', users))
+        .then(users => {
+          commit('SET_ALL_USERS', users)
+          return users
+        })
         .catch(error => {
           commit('SET_ALL_USERS', [])
           throw error


### PR DESCRIPTION
@Ezchan 

This isn't a bug fix, but I noticed if a student starts a project over after an instructor has cached a copy of the completion in their browser's IndexedDB, refreshing the page will try to sync that resource and fail, causing an error message to appear in the console. Instead of failing, now the code removes the cached resource from IndexedDB so that refreshing the page won't result in the error message appearing.