### PR TITLE
Install and activate service worker updates right away

### DIFF
--- a/frontend/src/service-worker.js
+++ b/frontend/src/service-worker.js
@@ -1,1 +1,14 @@
 import '@notifications/_helpers/handle-background-messages'
+
+// More info about service worker update lifecycle:
+// https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#updates
+
+// Claim all tabs right away (instead of after next page reload)
+self.addEventListener('activate', event => {
+  self.clients.claim()
+})
+
+// When a new service worker has been installed, activate it immediately
+self.addEventListener('install', event => {
+  self.skipWaiting()
+})


### PR DESCRIPTION
@Ezchan 

I _think_ this addresses the issue of reloading the page after the service worker updates. I can't reproduce it locally since making this change, but I'm also not sure what conditions invalidate old service workers.

I figure we can test in staging since you seemed to be able to reproduce this fairly consistently, right?