### PR TITLE
Changed empty string values to null for change comparisons/save errors

### DIFF
--- a/frontend/src/components/course-form-credits.vue
+++ b/frontend/src/components/course-form-credits.vue
@@ -31,6 +31,8 @@ export default {
         const newCreditsNumber = Number(newCredits)
         if (!isNaN(newCreditsNumber) && newCreditsNumber > 0) {
           this.course.credits = newCreditsNumber
+        } else {
+          this.course.credits = null
         }
       } else {
         this.$refs.input.value = this.course.credits

--- a/frontend/src/components/course-form-title.vue
+++ b/frontend/src/components/course-form-title.vue
@@ -5,6 +5,7 @@
       <input
         v-model="course.title"
         id="course-title"
+        @input="onInput"
         name="course-title"
         placeholder="A short description of the course in the infinitive form"
       >
@@ -21,6 +22,13 @@ export default {
     course: {
       type: Object,
       required: true
+    }
+  },
+  methods: {
+    onInput () {
+      if (this.course.title === '') {
+        this.course.title = null
+      }
     }
   }
 }

--- a/frontend/src/components/lesson-form-estimated-hours.vue
+++ b/frontend/src/components/lesson-form-estimated-hours.vue
@@ -35,6 +35,8 @@ export default {
         const newHoursNumber = parseInt(newHours)
         if (!isNaN(newHoursNumber) && newHoursNumber > 0) {
           this.lesson.estimatedHours = newHoursNumber
+        } else {
+          this.lesson.estimatedHours = null
         }
       } else {
         this.$refs.input.value = this.lesson.estimatedHours

--- a/frontend/src/components/lesson-form-notes.vue
+++ b/frontend/src/components/lesson-form-notes.vue
@@ -4,6 +4,7 @@
       <label for="lesson-notes">Notes</label>
       <textarea
         v-model="lesson.notes"
+        @input="onInput"
         id="lesson-notes"
         name="lesson-notes"
         placeholder="Additional notes for future instructors"
@@ -18,6 +19,13 @@ export default {
     lesson: {
       type: Object,
       required: true
+    }
+  },
+  methods: {
+    onInput () {
+      if (this.lesson.notes === '') {
+        this.lesson.notes = null
+      }
     }
   }
 }

--- a/frontend/src/components/lesson-form-project.vue
+++ b/frontend/src/components/lesson-form-project.vue
@@ -7,6 +7,7 @@
           <input
             v-model="lesson.projectTitle"
             placeholder="Project title"
+            @input="onInput"
             id="project-title"
             name="project-title"
             class="lesson-project-title-input"
@@ -93,6 +94,11 @@ export default {
         position: this.lesson.projectCriteria.length
       })
       this.newProjectCriterion = ''
+    },
+    onInput () {
+      if (this.lesson.projectTitle === '') {
+        this.lesson.projectTitle = null
+      }
     }
   }
 }

--- a/frontend/src/components/lesson-form-title.vue
+++ b/frontend/src/components/lesson-form-title.vue
@@ -5,6 +5,7 @@
       <input
         v-model="lesson.title"
         id="lesson-title"
+        @input="onInput"
         name="lesson-title"
         placeholder="A short description of the lesson in the infinitive form"
       >
@@ -21,6 +22,13 @@ export default {
     lesson: {
       type: Object,
       required: true
+    }
+  },
+  methods: {
+    onInput () {
+      if (this.lesson.title === '') {
+        this.lesson.title = null
+      }
     }
   }
 }


### PR DESCRIPTION
@egillespie 
These are the changes to correct data not matching when adding a space then removing it in empty fields when creating new lessons or courses that allowed you to attempt to save empty strings. This just converts them back to null. 