### PR TITLE
Conn pool config

### DIFF
--- a/backend/env/README.md
+++ b/backend/env/README.md
@@ -15,6 +15,13 @@ The name of the brand used in this environment. Choices are: `codelab517` or
 `msu`. The brand influences both the behavior of the application and how it
 looks to users.
 
+### `CODELAB_DB_CONN_POOL_SIZE`
+
+The number of database connections to allocate for the pool. These connections
+will be shared by all worker threads. Choose a value smaller than the number
+of connections allowed by the database so direct connections can be made for
+troubleshooting, data fixes, reports, etc. The default value is `10`.
+
 ### `CODELAB_DB_HOST`
 
 The hostname or IP address of the application's database server. The default

--- a/backend/env/db-conn-pool-size.js
+++ b/backend/env/db-conn-pool-size.js
@@ -1,0 +1,1 @@
+module.exports = parseInt(process.env.CODELAB_DB_CONN_POOL_SIZE) || 10

--- a/backend/src/db/sequelize.js
+++ b/backend/src/db/sequelize.js
@@ -17,6 +17,7 @@ pg.types.setTypeParser(1114, dateString => {
 
 import Sequelize from 'sequelize'
 import databaseUrl from '../../env/database-url'
+import dbConnPoolSize from '../../env/db-conn-pool-size'
 import logSqlStatements from '../../env/log-sql-statements'
 
 export default new Sequelize(
@@ -27,7 +28,7 @@ export default new Sequelize(
     logging: logSqlStatements ? console.log : false,
     benchmark: true,
     pool: {
-      max: 18
+      max: dbConnPoolSize
     },
     operatorsAliases: false,
     define: {


### PR DESCRIPTION
@Ezchan 

I plan on upgrading our production database server to 120 connections (the base plan's limit is 20). To avoid a deployment to accommodate this, I added an environment variable to allow us to increase the connection pool size (or lower it).

I also lowered the default size to 10 to match the default of the `node-postgres` library and to make sure we have several connections available for troubleshooting if we need it.