### PR TITLE
Only show code reviews where you are an instructor in the course

### DIFF
--- a/frontend/src/components/code-reviews-courses.vue
+++ b/frontend/src/components/code-reviews-courses.vue
@@ -21,7 +21,6 @@
 import InstructorCodeReviews from '@components/code-reviews-instructor'
 import { projectCompletionGetters } from '@state/helpers'
 import courseUserGradeCurrentRounded from '@helpers/computed/course-user-grade-current-rounded'
-import courseById from '@helpers/finders/course-by-id'
 import lessonById from '@helpers/finders/lesson-by-id'
 import userById from '@helpers/finders/user-by-id'
 import orderBy from 'lodash/orderBy'
@@ -54,7 +53,13 @@ export default {
           instructorCodeReviews[projectCompletion.instructorUserId] = []
         }
 
-        const course = courseById(projectCompletion.courseId)
+        // Find the course in the ones provided to this component to make sure
+        // the current user has permission to do code reviews for the course
+        const course = this.courses.find(
+          course => course.courseId === projectCompletion.courseId
+        )
+        if (!course) return
+
         const lesson = lessonById(projectCompletion.lessonId)
         const student = userById(projectCompletion.studentUserId)
         const grade = courseUserGradeCurrentRounded(course, student)

--- a/frontend/src/pages/code-reviews.vue
+++ b/frontend/src/pages/code-reviews.vue
@@ -6,10 +6,9 @@
 </template>
 
 <script>
-import store from '@state/store'
 import Layout from '@layouts/main'
 import CoursesCodeReviews from '@components/code-reviews-courses'
-import { courseGetters } from '@state/helpers'
+import { courseGetters, userGetters } from '@state/helpers'
 
 export default {
   components: {
@@ -17,8 +16,9 @@ export default {
   },
   computed: {
     ...courseGetters,
+    ...userGetters,
     availableCourses () {
-      const currentUserId = store.state.users.currentUser.userId
+      const currentUserId = this.currentUser.userId
       return this.courses.filter(
         course => course.instructorIds.some(userId => userId === currentUserId)
       )


### PR DESCRIPTION
@Ezchan 

The list of courses provided to this component have been pre-filtered to only include courses the instructor is assigned to. By matching the project completions to that list instead of the global list, it will prevent a student who is also an instructor from being able to see code reviews where they are the student.