### PR TITLE
Use different course prefix for Code Lab 517

### DIFF
--- a/frontend/src/pages/course-new.vue
+++ b/frontend/src/pages/course-new.vue
@@ -74,13 +74,14 @@ import Layout from '@layouts/main'
 import store from '@state/store'
 import { userGetters, courseGetters } from '@state/helpers'
 import createCourse from '@api/courses/create-course'
+import brand from '@env/brand'
 
 export default {
   components: {
     Layout
   },
   data () {
-    const prefixOptions = ['MI']
+    const prefixOptions = brand === 'msu' ? ['MI'] : ['LAB']
     const semesterOptions = {
       Spring: 'SS',
       Summer: 'US',


### PR DESCRIPTION
@Ezchan 

`MI` didn't seem very fitting for Code Lab 517, so I adjusted the course prefix by brand.