### PR TITLE
Spinula fix

### DIFF
--- a/frontend/src/state/modules/_helpers/lesson-fully-loaded.js
+++ b/frontend/src/state/modules/_helpers/lesson-fully-loaded.js
@@ -1,7 +1,0 @@
-export default lesson => (
-  lesson &&
-  (
-    (lesson.content && lesson.content.length) ||
-    (lesson.notes && lesson.notes.length)
-  )
-)


### PR DESCRIPTION
@Ezchan This fixes the "content loading" icon appearing (and never disappearing) when all of the lessons are synced in the background of the application. Now when the lessons are synced, the current lesson's content will be re-downloaded so they get the latest content instead of no content.