### PR TITLE
Add JSX code highlighting support

### DIFF
--- a/frontend/src/helpers/utils/dom/syntax-highlight.js
+++ b/frontend/src/helpers/utils/dom/syntax-highlight.js
@@ -12,6 +12,7 @@ export const codeLangs = {
   js: javascript,
   json: javascript,
   javascript: javascript,
+  jsx: javascript,
   ejs: xml,
   html: xml,
   sh: bash,


### PR DESCRIPTION
@Ezchan This change will use the JavaScript code renderer to show syntax highlighting of JSX (React) code examples.