### PR TITLE
Save the timestamp that a resource was last synced

### DIFF
--- a/frontend/src/state/modules/resource-journal.js
+++ b/frontend/src/state/modules/resource-journal.js
@@ -23,7 +23,7 @@ export default {
             return get(resourceId).then(journal => {
               // Look for journal entries that were changed since the last sync
               const { resourceType, timestamp } = journal
-              if (timestamp < state.lastSyncTimestamp) return
+              if (timestamp <= state.lastSyncTimestamp) return
               return dispatch('syncResource', {
                 resourceType, resourceId, syncTimestamp
               })


### PR DESCRIPTION
@KatieMFritz

When someone focuses a Code Lab tab, the app looks in a local database to see if there were any changes made while the page was inactive. It uses a timestamp to get any changes that were made after the last sync. Too bad I wasn't actually saving the timestamp on the records after syncing them...

So this change saves when each resource was last synced so that when a tab becomes active, it doesn't re-download ALL previously downloaded resources. 😥 