### PR TITLE
Hosted site URL fixes

### DIFF
--- a/frontend/src/helpers/computed/course-project-completion-hosted-subdomain.js
+++ b/frontend/src/helpers/computed/course-project-completion-hosted-subdomain.js
@@ -24,6 +24,8 @@ export default projectCompletion => {
 
   const subdomain = `${username}-${domainSuffix}`
     .toLowerCase()
+    // add 'u' to front if the subdomain begins with a number
+    .replace(/^([0-9].*)/, 'u$1')
     // ensure the string does not exceed the max length
     .slice(0, maxChars)
     // remove special characters from the end

--- a/frontend/test/unit/specs/helpers/computed/course-project-completion-hosted-subdomain.spec.js
+++ b/frontend/test/unit/specs/helpers/computed/course-project-completion-hosted-subdomain.spec.js
@@ -64,6 +64,13 @@ describe('@helpers/computed/course-project-completion-hosted-subdomain.js', () =
     expect(domain).to.equal('eriklgillespie-css-frameworks')
   })
 
+  it('prevents subdomains from beginning with a number', () => {
+    user.githubLogin = '80egillespie'
+    lesson.lessonKey = 'html-intro-to-semantic-elements'
+    const domain = courseProjectCompletionHostedSubdomain(completion)
+    expect(domain).to.equal('u80egillespie-html-intro-to-se')
+  })
+
   it('produces non-cryptic subdomains for real users and projects', () => {
     user.githubLogin = 'erik.gillespie'
     lesson.lessonKey = 'html-terminal-and-git'


### PR DESCRIPTION
1. Prevent hosted site subdomains from ending in special characters
2. Prevent hosted site domain from starting with a number
3. Add comments for all of the string mutations