### PR TITLE
Use consistently scaled rounding technique to account for JS rounding…

### DIFF
--- a/frontend/src/helpers/utils/get-grade-rounded.js
+++ b/frontend/src/helpers/utils/get-grade-rounded.js
@@ -1,7 +1,8 @@
 import gradeMax from '@constants/grade-max'
+import round from './round'
 
 export default grade => {
   if (isNaN(grade)) return 0
   if (grade > gradeMax) return gradeMax
-  return Math.floor(grade * 100) / 100
+  return round(grade)
 }

--- a/frontend/src/helpers/utils/round.js
+++ b/frontend/src/helpers/utils/round.js
@@ -1,0 +1,7 @@
+// Adaptation of consistent scaled rounding technique:
+// https://stackoverflow.com/a/11832950/1696044
+
+export default (number, digits = 2) => {
+  const scale = Math.pow(10, digits)
+  return Math.round((number + Number.EPSILON) * scale) / scale
+}

--- a/frontend/test/unit/specs/helpers/computed/course-user-grade-current-rounded.spec.js
+++ b/frontend/test/unit/specs/helpers/computed/course-user-grade-current-rounded.spec.js
@@ -2,11 +2,6 @@ import store from '@state/store'
 import courseUserGradeCurrentRounded from '@helpers/computed/course-user-grade-current-rounded'
 
 describe('@helpers/computed/course-user-grade-current-rounded.js', () => {
-  const course = {
-    courseId: 21,
-    credits: 2
-  }
-
   const user = {
     userId: 71
   }
@@ -15,12 +10,33 @@ describe('@helpers/computed/course-user-grade-current-rounded.js', () => {
     { lessonId: 1, estimatedHours: 7.0 },
     { lessonId: 2, estimatedHours: 7.0 },
     { lessonId: 3, estimatedHours: 8.0 },
-    { lessonId: 4, estimatedHours: 6.0 }
+    { lessonId: 4, estimatedHours: 6.0 },
+    { lessonId: 200, estimatedHours: 3.0 },
+    { lessonId: 201, estimatedHours: 2.0 },
+    { lessonId: 203, estimatedHours: 2.0 },
+    { lessonId: 204, estimatedHours: 2.0 },
+    { lessonId: 205, estimatedHours: 1.0 },
+    { lessonId: 207, estimatedHours: 1.0 },
+    { lessonId: 208, estimatedHours: 2.0 },
+    { lessonId: 209, estimatedHours: 1.0 },
+    { lessonId: 210, estimatedHours: 1.0 },
+    { lessonId: 211, estimatedHours: 1.0 },
+    { lessonId: 212, estimatedHours: 2.0 },
+    { lessonId: 213, estimatedHours: 2.0 },
+    { lessonId: 214, estimatedHours: 3.0 },
+    { lessonId: 217, estimatedHours: 2.0 },
+    { lessonId: 218, estimatedHours: 2.0 },
+    { lessonId: 219, estimatedHours: 3.0 },
+    { lessonId: 220, estimatedHours: 2.0 },
+    { lessonId: 221, estimatedHours: 3.0 },
+    { lessonId: 222, estimatedHours: 3.0 },
+    { lessonId: 224, estimatedHours: 3.0 },
+    { lessonId: 239, estimatedHours: 1.0 }
   ]
 
-  const addProject = (lessonId, studentUserId, submitted, approved) => {
+  const addProject = (courseId, lessonId, studentUserId, submitted, approved) => {
     const projectCompletions = store.getters.projectCompletions
-    const completion = { courseId: 21, lessonId, studentUserId }
+    const completion = { courseId, lessonId, studentUserId }
 
     if (submitted) {
       completion.firstSubmittedAt = Date.now()
@@ -45,48 +61,82 @@ describe('@helpers/computed/course-user-grade-current-rounded.js', () => {
   })
 
   it('returns 0 for 0 projects started', () => {
+    const course = { courseId: 21, credits: 2 }
     expect(courseUserGradeCurrentRounded(course, user)).to.equal(0)
   })
 
   it('returns 2.0 for half of lesson hours approved', () => {
-    addProject(1, 71, true, true)
-    addProject(2, 71, true, true)
+    const course = { courseId: 21, credits: 2 }
+    addProject(course.courseId, lessons[0].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[1].lessonId, user.userId, true, true)
     expect(courseUserGradeCurrentRounded(course, user)).to.equal(2)
   })
 
-  it('returns 0.85 for 6 of 28 lesson hours approved', () => {
-    addProject(4, 71, true, true)
-    expect(courseUserGradeCurrentRounded(course, user)).to.equal(0.85)
+  it('returns 0.86 for 6 of 28 lesson hours approved', () => {
+    const course = { courseId: 21, credits: 2 }
+    addProject(course.courseId, lessons[3].lessonId, user.userId, true, true)
+    expect(courseUserGradeCurrentRounded(course, user)).to.equal(0.86)
   })
 
   it('returns 4.0 for all projects approved', () => {
-    addProject(1, 71, true, true)
-    addProject(2, 71, true, true)
-    addProject(3, 71, true, true)
-    addProject(4, 71, true, true)
+    const course = { courseId: 21, credits: 2 }
+    addProject(course.courseId, lessons[0].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[1].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[2].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[3].lessonId, user.userId, true, true)
+    expect(courseUserGradeCurrentRounded(course, user)).to.equal(4)
+  })
+
+  it('returns 4.0 for real 3-credit course', () => {
+    const course = { courseId: 5931, credits: 3 }
+    addProject(course.courseId, 200, user.userId, true, true)
+    addProject(course.courseId, 201, user.userId, true, true)
+    addProject(course.courseId, 203, user.userId, true, true)
+    addProject(course.courseId, 204, user.userId, true, true)
+    addProject(course.courseId, 205, user.userId, true, true)
+    addProject(course.courseId, 207, user.userId, true, true)
+    addProject(course.courseId, 208, user.userId, true, true)
+    addProject(course.courseId, 209, user.userId, true, true)
+    addProject(course.courseId, 210, user.userId, true, true)
+    addProject(course.courseId, 211, user.userId, true, true)
+    addProject(course.courseId, 212, user.userId, true, true)
+    addProject(course.courseId, 213, user.userId, true, true)
+    addProject(course.courseId, 214, user.userId, true, true)
+    addProject(course.courseId, 217, user.userId, true, true)
+    addProject(course.courseId, 218, user.userId, true, true)
+    addProject(course.courseId, 219, user.userId, true, true)
+    addProject(course.courseId, 220, user.userId, true, true)
+    addProject(course.courseId, 221, user.userId, true, true)
+    addProject(course.courseId, 222, user.userId, true, true)
+    addProject(course.courseId, 224, user.userId, true, true)
+    addProject(course.courseId, 239, user.userId, true, true)
     expect(courseUserGradeCurrentRounded(course, user)).to.equal(4)
   })
 
   it('ignores other student projects', () => {
-    addProject(1, 71, true, true)
-    addProject(2, 71, true, true)
-    addProject(1, 75, true, true)
+    const course = { courseId: 21, credits: 2 }
+    const otherUserId = user.userId + 1
+    addProject(course.courseId, lessons[0].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[1].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[0].lessonId, otherUserId, true, true)
     expect(courseUserGradeCurrentRounded(course, user)).to.equal(2)
   })
 
   it('ignores unsubmitted projects', () => {
-    addProject(1, 71, true, true)
-    addProject(2, 71, true, true)
-    addProject(3, 71, false)
-    addProject(4, 71, false)
+    const course = { courseId: 21, credits: 2 }
+    addProject(course.courseId, lessons[0].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[1].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[2].lessonId, user.userId, false)
+    addProject(course.courseId, lessons[3].lessonId, user.userId, false)
     expect(courseUserGradeCurrentRounded(course, user)).to.equal(2)
   })
 
   it('ignores unapproved projects', () => {
-    addProject(1, 71, true, true)
-    addProject(2, 71, true, true)
-    addProject(3, 71, true, false)
-    addProject(4, 71, true, false)
+    const course = { courseId: 21, credits: 2 }
+    addProject(course.courseId, lessons[0].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[1].lessonId, user.userId, true, true)
+    addProject(course.courseId, lessons[2].lessonId, user.userId, true, false)
+    addProject(course.courseId, lessons[3].lessonId, user.userId, true, false)
     expect(courseUserGradeCurrentRounded(course, user)).to.equal(2)
   })
 })

--- a/frontend/test/unit/specs/helpers/utils/get-grade-rounded.spec.js
+++ b/frontend/test/unit/specs/helpers/utils/get-grade-rounded.spec.js
@@ -13,8 +13,17 @@ describe('@helpers/utils/get-grade-rounded.js', () => {
     expect(getGradeRounded(3.12345)).to.equal(3.12)
   })
 
-  it('always rounds down', () => {
-    expect(getGradeRounded(2.11999)).to.equal(2.11)
+  it('rounds 0.0000000001 to 0.0499999999 down to 2 decimal places', () => {
+    expect(getGradeRounded(2.1100000001)).to.equal(2.11)
+    expect(getGradeRounded(2.111)).to.equal(2.11)
+    expect(getGradeRounded(2.113)).to.equal(2.11)
+    expect(getGradeRounded(2.1149999999)).to.equal(2.11)
+  })
+
+  it('rounds 0.005 to 0.0099999999 up to 2 decimal places', () => {
+    expect(getGradeRounded(2.115)).to.equal(2.12)
+    expect(getGradeRounded(2.119)).to.equal(2.12)
+    expect(getGradeRounded(2.1199999999)).to.equal(2.12)
   })
 
   it('rounds down to max grade', () => {

--- a/frontend/test/unit/specs/helpers/utils/round.spec.js
+++ b/frontend/test/unit/specs/helpers/utils/round.spec.js
@@ -1,0 +1,37 @@
+import round from '@helpers/utils/round'
+
+describe('@helpers/utils/round.js', () => {
+  it('rounds whole numbers to whole numbers', () => {
+    for (let wholeNumber = 0; wholeNumber <= 4; wholeNumber++) {
+      expect(round(wholeNumber)).to.equal(wholeNumber)
+    }
+  })
+
+  it('rounds special case 1.005 to 1.01', () => {
+    expect(round(1.005)).to.equal(1.01)
+  })
+
+  it('rounds half and larger up', () => {
+    expect(round(1.007)).to.equal(1.01)
+    expect(round(1.009)).to.equal(1.01)
+    expect(round(1.009999999999)).to.equal(1.01)
+  })
+
+  it('rounds less than half down', () => {
+    expect(round(1.014)).to.equal(1.01)
+    expect(round(1.013)).to.equal(1.01)
+    expect(round(1.011)).to.equal(1.01)
+    expect(round(1.014999999999)).to.equal(1.01)
+  })
+
+  it('rounds to expected number of digits', () => {
+    expect(round(1.5454545, 0)).to.equal(2)
+    expect(round(1.5454545, 1)).to.equal(1.5)
+    expect(round(1.5454545, 2)).to.equal(1.55)
+    expect(round(1.5454545, 3)).to.equal(1.545)
+    expect(round(1.5454545, 4)).to.equal(1.5455)
+    expect(round(1.5454545, 5)).to.equal(1.54545)
+    expect(round(1.5454545, 6)).to.equal(1.545455)
+    expect(round(1.5454545, 7)).to.equal(1.5454545)
+  })
+})


### PR DESCRIPTION
Fixes the grade rounding to use a [consistently scaled rounding technique](https://stackoverflow.com/a/11832950/1696044) that accounts for a rounding bug in some JavaScript implementations.

Resolves #266 