### PR TITLE
Right-align menu and remove duplicate header content

### DIFF
--- a/frontend/src/components/user-menu.vue
+++ b/frontend/src/components/user-menu.vue
@@ -1,22 +1,14 @@
 <template>
   <nav id="user-menu" aria-label="User Menu">
     <header aria-haspopup="true">
-      <a ref="collapsed-header" @click="toggleMenu" href="javascript:void(0)">
+      <a @click="toggleMenu" href="javascript:void(0)">
         <span>{{ currentUser.fullName }}</span><span
-          class="ml-1 fas fa-caret-down"
+          class="menu-indicator fas fa-caret-down"
           role="img"
         ></span>
       </a>
     </header>
     <section :aria-expanded="showMenu || 'false'">
-      <header>
-        <a ref="expanded-header" @click="toggleMenu" href="javascript:void(0)">
-          <span v-html="currentUser.fullName"></span><span
-            class="ml-1 fas fa-caret-down"
-            role="img"
-          ></span>
-        </a>
-      </header>
       <ol>
         <li>
           <router-link to="/profile">
@@ -25,7 +17,7 @@
         </li>
         <li v-if="hasNewGitHubScopes">
           <AuthLink provider="github">
-            {{ connectGitHubLabel }}
+            Connect GitHub
           </AuthLink>
         </li>
         <li>
@@ -58,20 +50,14 @@ export default {
     document.removeEventListener('click', this.hideMenu)
   },
   computed: {
-    ...userGetters,
-    connectGitHubLabel () {
-      return this.currentUser.githubLogin
-        ? 'Reconnect GitHub'
-        : 'Connect GitHub'
-    }
+    ...userGetters
   },
   methods: {
     toggleMenu () {
       this.showMenu = !this.showMenu
-      const headerRef = this.showMenu ? 'expanded-header' : 'collapsed-header'
-      this.$nextTick(() => this.$refs[headerRef].focus())
     },
     hideMenu (e) {
+      // Hide menu when user clicks off the menu
       if (!this.$el.contains(e.target)) {
         this.showMenu = false
       }
@@ -84,28 +70,41 @@ export default {
 @import '../meta'
 
 $halfGutterWidth = $design.layout.gutterWidth * .5
+$menuIndicatorOffset = .25rem
+$menuPinWidth = .5rem
+$menuOffset = -($menuPinWidth + $menuIndicatorOffset)
 
 nav
   position: relative
   border-left: 1px solid $design.control.border.color
   padding-left: $design.layout.gutterWidth
+  .menu-indicator
+    margin-left: $menuIndicatorOffset
   section
     display: none
     &[aria-expanded='true']
       display: block
       position: absolute
-      top: 0
-      left: $halfGutterWidth
-      margin-top: -($halfGutterWidth)
+      top: 30px
+      right: $menuOffset
       border-radius: $design.control.border.radius
-      box-shadow: 0 2px 8px rgba(0, 0, 0, .33)
+      filter: drop-shadow(0 2px 8px rgba(0, 0, 0, .33))
       background-color: $design.branding.default.light
       border: 1px solid $design.control.border.color
       padding: $halfGutterWidth
       z-index: 20
-  ol
-    list-style-type: none
-    border-top: 1px solid $design.control.border.color
-    padding: $halfGutterWidth $halfGutterWidth 0
-    margin-top: $halfGutterWidth
+    > ol
+      list-style-type: none
+      padding: $halfGutterWidth
+      &:after
+        position: absolute
+        right: $menuPinWidth
+        margin-left: -($menuPinWidth)
+        top: -($menuPinWidth)
+        width: 0
+        height: 0
+        content: ''
+        border-left: $menuPinWidth solid transparent
+        border-right: $menuPinWidth solid transparent
+        border-bottom: $menuPinWidth solid white
 </style>


### PR DESCRIPTION
1. Right-align the menu so "Connect GitHub" is always visible. The text would run off the right side of the page if "Connect GitHub" was longer than the user's full name.
2. Remove the duplicate header in the menu. This improves accessibility while simplifying the expand logic.