### PR TITLE
Add heroku create command to update instructions

### DIFF
--- a/frontend/src/components/project-completion-update-instructions.vue
+++ b/frontend/src/components/project-completion-update-instructions.vue
@@ -39,6 +39,9 @@
       # 1) Navigate to your project directory (unless you're already there)
       cd PATH/TO/{{ projectName }}
 
+      # 2) Create the app on Heroku (if you haven't already)
+      heroku create {{ projectHostedSubdomain }}
+
       # 3) Push your committed code to Heroku
       git push heroku main
     </CodeBlock>


### PR DESCRIPTION
Show the `heroku create` command on the Project instructions even when updating, since some students miss the command before running `git push origin main`.

See #315 for more information.